### PR TITLE
add clear rgb for multiple run

### DIFF
--- a/taichi_ngp.py
+++ b/taichi_ngp.py
@@ -725,8 +725,10 @@ class NGP_fw:
         plt.imsave('taichi_ngp.png', (rgb_np*255).astype(np.uint8))
         plt.imsave('taichi_ngp_depth.png', depth2img(depth_np))
 
-    def render(self, max_samples, T_threshold, use_dof=False, dist_to_focus=0.8, len_dis=0.0) -> Tuple[float, int, int]:
+    def render(self, max_samples, T_threshold, use_dof=False, dist_to_focus=0.8, len_dis=0.0, clear_rgb=True) -> Tuple[float, int, int]:
         samples = 0
+        if clear_rgb:
+            self.rgb.fill(0.0)
         self.reset()
         self.gen_noise_buffer()
         if use_dof:
@@ -920,6 +922,7 @@ class NGP_fw:
                 use_dof=use_dof,
                 dist_to_focus=dist_to_focus,
                 len_dis=len_dis,
+                clear_rgb=False
             )
 
             if not show_depth:


### PR DESCRIPTION
This pr should resolve #4 

## Problem

If the user wants to render the scene without GUI, the `render()` function is not automatically clear the `rgb`, so if we run `render()` multiple times, the `rgb` will keep accumulating.

## Solution

Add a flag `clear_rgb` to indicate whether to clear the `rgb` or not, the default is `True`.